### PR TITLE
docs: README rewrite with prerequisites and best practice alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,11 @@ cython_debug/
 # Learn more at https://abstra.io/docs
 .abstra/
 
+# Claude Code — local/session files (not committed)
+STATUS.md
+CLAUDE.local.md
+.claude/settings.local.json
+
 # Visual Studio Code
 #  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,5 +85,15 @@
 <!-- - API endpoints must follow REST conventions in docs/api-guide.md -->
 <!-- - All new components need Storybook stories -->
 
+## Testing
+
+<!-- CUSTOMIZE: Define how to run tests for your project. Examples: -->
+<!-- - Run tests: `pytest` -->
+<!-- - Run tests: `npm test` or `vitest` -->
+<!-- - Run linter: `ruff check .` -->
+
+<!-- TIP: Create CLAUDE.local.md for personal preferences (language, local paths, editor settings).
+     It's auto-gitignored and never committed to the repo. -->
+
 <!-- You're done! Save this file, commit it to git, and start Claude Code.
      Claude reads CLAUDE.md automatically — no extra configuration needed. -->

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,8 +2,22 @@
 
 ## Prerequisites
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed (`npm install -g @anthropic-ai/claude-code`)
-- A Claude subscription (Pro, Team, or Enterprise)
+**Install Claude Code** — pick one method:
+
+```bash
+# Recommended (standalone installer)
+curl -fsSL https://claude.ai/install.sh | bash
+
+# macOS (Homebrew)
+brew install --cask claude-code
+
+# Cross-platform (Node.js 18+)
+npm install -g @anthropic-ai/claude-code
+```
+
+**Subscription required:** Claude Pro, Max, Team, or Enterprise — or an [Anthropic Console](https://console.anthropic.com/) account with API credits.
+
+> Full install docs: [docs.anthropic.com/en/docs/claude-code/overview](https://docs.anthropic.com/en/docs/claude-code/overview)
 
 ## Setup
 
@@ -44,15 +58,32 @@ cp -r .claude/ /path/to/your-project/
 cd /path/to/your-project && claude
 ```
 
+## Personal Preferences — CLAUDE.local.md
+
+Create `CLAUDE.local.md` in your project root for settings that shouldn't be committed:
+
+```markdown
+# CLAUDE.local.md — Personal preferences (auto-gitignored)
+
+- Respond in Danish
+- Python: /opt/homebrew/bin/python3.12
+- Prefer parallel subagents for multi-file tasks
+```
+
+Claude reads this automatically alongside `CLAUDE.md`. It's gitignored by default — safe for local paths, language preferences, and personal workflows.
+
 ## What's Included
 
 | File | What It Does |
 |---|---|
 | `CLAUDE.md` | Project memory template with commented sections |
-| `.claude/rules/` | Git workflow, code style, session discipline |
-| `.claude/hooks/` | Block push to main, auto-format Python |
-| `.claude/agents/` | Code reviewer agent |
-| `docs/` | Full documentation and workshop guide |
+| `.claude/rules/` | Git workflow, code style, security, testing, session discipline |
+| `.claude/hooks/` | Branch protection, auto-lint, secret scanning, context monitoring |
+| `.claude/agents/` | Code reviewer, security reviewer, quality gate, 5 test specialists |
+| `prompts/` | Prompt templates and divergent thinking frameworks |
+| `guides/` | Agentic engineering patterns, adversarial review, parallel execution |
+| `tools/` | Gemini-powered external code review CLI |
+| `docs/` | Full documentation, cheat sheet, and workshop guide |
 | `examples/` | CLAUDE.md templates for Python, TypeScript, and non-coders |
 | `exercises/` | 4 hands-on exercises to learn the setup |
 
@@ -67,8 +98,22 @@ Don't code? No problem. You can set up a project without touching any config fil
 5. Paste it into Claude Code and answer the questions
 6. Done — Claude sets up everything for you
 
-## Next
+## Troubleshooting
 
+**Hooks aren't running?**
+Make sure they're executable: `chmod +x .claude/hooks/*.sh`
+
+**Claude doesn't know the conventions?**
+Verify `CLAUDE.md` exists in the project root. Claude reads it automatically on startup.
+
+**Permission denied on tool calls?**
+Check `.claude/settings.json` — hooks may be blocking actions. Run `claude` with `--verbose` to see which hooks fire.
+
+## Next Steps
+
+- Run `/compact` after completing a feature to reclaim context
+- Run `/clear` when switching tasks
+- Use `Shift+Tab` to toggle plan mode (scope work before coding)
 - Read the docs in `docs/` for full explanations
 - Try the exercises in `exercises/` to learn hands-on
 - Check `examples/` for CLAUDE.md templates for your stack

--- a/README.md
+++ b/README.md
@@ -1,33 +1,85 @@
 # Claude Code Quickstart
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A battle-tested starter kit for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Clone it, customize it, and get productive in 60 seconds.
 
 **This is not a link collection or a config dump.** It's an opinionated, progressive setup that teaches you the patterns that actually matter — from your first CLAUDE.md to automated guardrails and AI-powered code review.
 
-## What's Inside
+## Prerequisites
 
-- **CLAUDE.md template** — Commented, ready to customize for your project
-- **Rules (7)** — Git workflow, code style, session discipline, testing, Python conventions, web safety, session end protocol, security
-- **Hooks (9)** — Auto-lint, branch protection, critical file protection, pre-push review gate, secret scanning, context monitoring, test reminders, session lifecycle
-- **Agents (9)** — Code reviewer, security reviewer, explorer, quality gate, unit/integration/data/UAT/regression testers
-- **Prompts** — Battle-tested templates including 5 divergent thinking frameworks
-- **Guides** — Agentic engineering patterns, multi-AI adversarial review, parallel execution
-- **Tools** — Gemini-powered external code review CLI
-- **Docs** — Why each piece matters, with examples
-- **Exercises** — 4 hands-on exercises from beginner to advanced
-- **Examples** — CLAUDE.md templates for Python, TypeScript, and non-coders
+- **Claude Code** installed — pick one method:
+  - `curl -fsSL https://claude.ai/install.sh | bash` (recommended)
+  - `brew install --cask claude-code` (macOS)
+  - `npm install -g @anthropic-ai/claude-code` (cross-platform)
+- **Active subscription** — Claude Pro, Max, Team, or Enterprise — or an [Anthropic Console](https://console.anthropic.com/) account with API credits
+- **Git** installed
+- **A terminal** — macOS, Linux, or Windows (WSL recommended)
+
+> Full install docs: [docs.anthropic.com/en/docs/claude-code/overview](https://docs.anthropic.com/en/docs/claude-code/overview)
 
 ## Quick Start
 
 ```bash
+# 1. Install Claude Code (if you haven't already)
+curl -fsSL https://claude.ai/install.sh | bash
+
+# 2. Clone and enter
 git clone https://github.com/EduardPetraeus/claude-code-quickstart.git
 cd claude-code-quickstart
+
+# 3. Start Claude Code
 claude
+
+# 4. Verify — ask Claude:
+#    "What conventions does this project follow?"
 ```
 
-See [QUICKSTART.md](QUICKSTART.md) for full setup instructions.
+See [QUICKSTART.md](QUICKSTART.md) for detailed setup, verification steps, and troubleshooting.
 
 > **Not a programmer?** Start here → [IMPLEMENT.md](IMPLEMENT.md). Copy one prompt into Claude Code and it sets up everything for you.
+
+## How It Works
+
+Claude Code reads your project configuration in layers — each layer adds structure:
+
+```
+CLAUDE.md                  → Project brain. Loaded every request. Conventions, rules, context.
+.claude/rules/*.md         → Topic files. Git workflow, code style, security, testing.
+.claude/hooks/*.sh         → Automation. Enforced on every tool call (lint, protect, scan).
+.claude/agents/*.md        → Specialists. Code review, security audit, testing, exploration.
+```
+
+**CLAUDE.md** is the entry point — Claude reads it automatically. Rules add depth without bloating the main file. Hooks enforce guardrails you don't have to think about. Agents handle tasks that need focused expertise.
+
+## What's Inside
+
+- **CLAUDE.md template** — Commented, ready to customize for your project
+- **Rules (8)** — Git workflow, code style, session discipline, testing, Python conventions, web safety, session end protocol, security
+- **Hooks (9)** — Auto-lint, branch protection, critical file protection, pre-push review gate, secret scanning, context monitoring, test reminders, session lifecycle
+- **Agents (9)** — Code reviewer, security reviewer, explorer, quality gate, unit/integration/data/UAT/regression testers
+- **Prompts (8)** — Battle-tested templates including 5 divergent thinking frameworks
+- **Guides (3)** — Agentic engineering patterns, multi-AI adversarial review, parallel execution
+- **Tools (1)** — Gemini-powered external code review CLI
+- **Docs (7)** — Why each piece matters, with examples and a cheat sheet
+- **Exercises (4)** — Hands-on exercises from beginner to advanced
+- **Examples (3)** — CLAUDE.md templates for Python, TypeScript, and non-coders
+
+## Use It in Your Own Project
+
+```bash
+# 1. Copy the setup to your project
+cp CLAUDE.md /path/to/your-project/
+cp -r .claude/ /path/to/your-project/
+
+# 2. Edit CLAUDE.md — fill in the <!-- CUSTOMIZE --> sections
+#    (project name, stack, language preferences, project-specific rules)
+
+# 3. Start Claude Code in your project
+cd /path/to/your-project && claude
+```
+
+Create a `CLAUDE.local.md` for personal preferences (editor, language, local paths) — it's auto-gitignored and never committed.
 
 ## Who This Is For
 
@@ -44,54 +96,32 @@ This repo powers a 2.5-hour hands-on workshop. See [docs/workshop-guide.md](docs
 
 ```
 CLAUDE.md                        # The template — start here
-QUICKSTART.md                    # 60-second setup guide
+QUICKSTART.md                    # Setup guide with verification
 IMPLEMENT.md                     # Non-coder bootstrap — paste into Claude Code
 .claude/
   settings.json                  # Full hooks configuration (9 hooks)
-  rules/
-    code-style.md                # Naming conventions, formatting
-    git-workflow.md              # Branching, commits, PRs
-    session-discipline.md        # One task per session, handover format
-    testing.md                   # pytest patterns, AAA, naming
-    python-conventions.md        # snake_case, type hints, Ruff
-    web-safety.md                # WebFetch/WebSearch safety rules
-    session-end.md               # Session persistence, confidence scoring
-    security.md                  # Pre-push scanning, secret management
-  hooks/
-    protect-main.sh              # Block direct commits to main
-    auto-lint.sh                 # Auto-format on file save
-    protect-critical.sh          # Guard CLAUDE.md, workflows, pyproject.toml
-    pre-push-gate.sh             # Require review before pushing to main
-    bash-output-scan.sh          # Scan CLI output for leaked secrets
-    context-monitor.sh           # Track tool usage, warn on context rot
-    test-gate.sh                 # Remind to run tests before finishing
-    session-start.sh             # Check governance freshness on startup
-    session-end.sh               # Log session metadata
-  agents/
-    code-reviewer.md             # Convention compliance, bugs, readability
-    security-reviewer.md         # Adversarial security scanning
-    explorer.md                  # Divergent thinking advisor
-    quality-gate.md              # Aggregate quality score (0-100)
-    unit-tester.md               # Edge cases, boundaries, null handling
-    integration-tester.md        # API, services, DB queries
-    data-tester.md               # Schema, transforms, data quality
-    uat-tester.md                # End-to-end user scenarios
-    regression-tester.md         # Full suite, no new breakage
-prompts/                         # Prompt templates for better AI conversations
-  prompt-skeleton.md             # 5-field prompt framework
-  stuck-template.md              # Structured format for when you're stuck
-  autonomous-execution.md        # Hands-off autonomous workflow
-  broad-thinking/                # 5 divergent thinking templates
-guides/                          # Deep patterns and playbooks
-  agentic-engineering-patterns.md  # 3-level framework for AI agents
-  adversarial-review-playbook.md   # Multi-AI review with 5+ models
-  parallel-execution-patterns.md   # Parallel agent coordination
-tools/
-  ai-review.py                   # Gemini-powered external code review
-docs/                            # Why it works, how to use it
-examples/                        # CLAUDE.md for different project types
-exercises/                       # Learn by doing
+  rules/                         # 8 topic-specific rule files
+  hooks/                         # 9 automation scripts
+  agents/                        # 9 specialist agent definitions
+prompts/                         # 8 prompt templates + divergent thinking
+guides/                          # 3 deep pattern guides
+tools/                           # External review CLI
+docs/                            # 7 docs + cheat sheet
+examples/                        # CLAUDE.md for Python, TypeScript, non-coders
+exercises/                       # 4 hands-on exercises
 ```
+
+## Resources
+
+- [Claude Code Overview](https://docs.anthropic.com/en/docs/claude-code/overview) — official docs
+- [Claude Code Best Practices](https://docs.anthropic.com/en/docs/claude-code/best-practices) — Anthropic's recommended patterns
+- [Hooks Documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) — event-driven automation
+- [Settings Reference](https://docs.anthropic.com/en/docs/claude-code/settings) — permissions and configuration
+- [Cheat Sheet](docs/cheat-sheet.md) — keyboard shortcuts, commands, tips
+
+## Contributing
+
+Issues and PRs are welcome. If you've built a useful rule, hook, or agent — share it.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **Prerequisites section** added before Quick Start — all 3 Claude Code install methods (curl, brew, npm), subscription requirements, and link to official docs
- **How It Works section** — explains the CLAUDE.md → rules → hooks → agents hierarchy in 4 lines
- **Use It in Your Own Project** promoted from QUICKSTART.md to README for visibility, plus CLAUDE.local.md mention
- **Resources section** — links to Anthropic docs (overview, best practices, hooks, settings) and cheat sheet
- **QUICKSTART.md** expanded with troubleshooting, CLAUDE.local.md guidance, and next steps (`/compact`, `/clear`, `Shift+Tab`)
- **CLAUDE.md template** — added Testing placeholder and CLAUDE.local.md tip
- **.gitignore** — added STATUS.md, CLAUDE.local.md, settings.local.json (template user files that shouldn't be committed)

## Test plan

- [ ] Read README.md as a stranger — does it make sense from zero?
- [ ] Verify all internal links point to existing files
- [ ] Verify .gitignore additions don't exclude already-tracked files
- [ ] Security review: PASS (2 LOW findings, both documentation choices)

Generated with Claude Code