### PR TITLE
feat: add custom commands, file suggestions, and settings enhancements

### DIFF
--- a/.claude/commands/handover.md
+++ b/.claude/commands/handover.md
@@ -1,0 +1,39 @@
+Write a structured session handover for the current repo.
+
+## Instructions
+
+1. Detect which repo we're in based on the current working directory.
+
+2. Write the handover to `STATUS.md` in the project root.
+
+3. Use this template:
+
+   ```
+   ## Session Handover — YYYY-MM-DD
+
+   ### Done
+   - [bullet list of completed work this session]
+
+   ### Next Step
+   - [single most important next action]
+
+   ### Files Changed
+   - [list of modified files with brief description]
+
+   ### Decisions Made
+   - [key decisions with brief rationale]
+
+   ### Blockers / Open Questions
+   - [anything unresolved, or "None"]
+   ```
+
+4. If STATUS.md already exists, append the new handover at the top of the file (after any frontmatter). If it doesn't exist, create it.
+
+5. Confirm: print which file was written and a one-line summary.
+
+## Rules
+- This is the agent's job — do not ask the human to fill in the template.
+- Review the session context (files changed, git diff, conversation) to populate the template.
+- Keep each section to 1-5 bullets. Brevity over completeness.
+- All content in English (it goes into the repo).
+- If there's nothing meaningful to hand over, say so and skip writing.

--- a/.claude/commands/reflect.md
+++ b/.claude/commands/reflect.md
@@ -1,0 +1,41 @@
+Reflect on the current session and capture learnings.
+
+## Instructions
+
+1. Review what happened in this session:
+   - What tasks were worked on?
+   - What decisions were made?
+   - What worked well? What was slow or required retries?
+   - Were any new tools, techniques, or patterns discovered?
+
+2. For each insight worth keeping, write a brief learning:
+
+   ```
+   # [Short descriptive title]
+
+   **Date:** YYYY-MM-DD
+   **Context:** [Which project/task/session produced this insight]
+
+   ## Observation
+   [2-5 sentences. What happened? What was the insight?]
+
+   ## Pattern
+   [1-2 sentences. The reusable takeaway.]
+
+   ## Tags
+   [keyword tags, e.g., #hooks #testing #workflow]
+   ```
+
+3. Check if any recurring pattern has appeared multiple times:
+   - If a pattern repeats, propose promoting it to a rule in `.claude/rules/`
+   - Only promote with the user's explicit approval
+
+4. Check if anything in CLAUDE.md was incorrect or missing during this session.
+   If yes, propose a specific, minimal change. If not, stay silent.
+
+5. Summarize what was captured (or state "No learnings worth capturing this session").
+
+## Rules
+- A reflection is 3-5 sentences per learning. Not an essay.
+- Default is silence. If the session was tactical (small fix, quick query), say "No learnings" and stop.
+- All file content in English.

--- a/.claude/hooks/file-suggestion.sh
+++ b/.claude/hooks/file-suggestion.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Custom @ file suggestion: prioritize project files, config, and docs
+# Returns JSON array of file suggestions for the @ autocomplete
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // "."')
+
+SUGGESTIONS=()
+
+# Project config files
+[ -f "$CWD/CLAUDE.md" ] && SUGGESTIONS+=("$CWD/CLAUDE.md")
+[ -f "$CWD/CLAUDE.local.md" ] && SUGGESTIONS+=("$CWD/CLAUDE.local.md")
+[ -f "$CWD/STATUS.md" ] && SUGGESTIONS+=("$CWD/STATUS.md")
+[ -f "$CWD/.claude/settings.json" ] && SUGGESTIONS+=("$CWD/.claude/settings.json")
+
+# Rules and agents
+for f in "$CWD/.claude/rules/"*.md; do
+  [ -f "$f" ] && SUGGESTIONS+=("$f")
+done
+for f in "$CWD/.claude/agents/"*.md; do
+  [ -f "$f" ] && SUGGESTIONS+=("$f")
+done
+
+# Output as JSON array
+printf '['
+first=true
+for s in "${SUGGESTIONS[@]}"; do
+  if [ "$first" = true ]; then
+    first=false
+  else
+    printf ','
+  fi
+  printf '"%s"' "$s"
+done
+printf ']'
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "fileSuggestion": {
+    "type": "command",
+    "command": "bash .claude/hooks/file-suggestion.sh"
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -60,6 +64,17 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/test-gate.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Claude is waiting for input'"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ CLAUDE.md                  → Project brain. Loaded every request. Conventions,
 
 - **CLAUDE.md template** — Commented, ready to customize for your project
 - **Rules (8)** — Git workflow, code style, session discipline, testing, Python conventions, web safety, session end protocol, security
-- **Hooks (9)** — Auto-lint, branch protection, critical file protection, pre-push review gate, secret scanning, context monitoring, test reminders, session lifecycle
+- **Hooks (10)** — Auto-lint, branch protection, critical file protection, pre-push review gate, secret scanning, context monitoring, test reminders, session lifecycle, file suggestions
 - **Agents (9)** — Code reviewer, security reviewer, explorer, quality gate, unit/integration/data/UAT/regression testers
+- **Commands (2)** — Session handover (`/project:handover`) and reflection (`/project:reflect`)
 - **Prompts (8)** — Battle-tested templates including 5 divergent thinking frameworks
 - **Guides (3)** — Agentic engineering patterns, multi-AI adversarial review, parallel execution
 - **Tools (1)** — Gemini-powered external code review CLI
@@ -99,9 +100,10 @@ CLAUDE.md                        # The template — start here
 QUICKSTART.md                    # Setup guide with verification
 IMPLEMENT.md                     # Non-coder bootstrap — paste into Claude Code
 .claude/
-  settings.json                  # Full hooks configuration (9 hooks)
+  settings.json                  # Full hooks + file suggestion config
+  commands/                      # 2 custom slash commands (handover, reflect)
   rules/                         # 8 topic-specific rule files
-  hooks/                         # 9 automation scripts
+  hooks/                         # 10 automation scripts
   agents/                        # 9 specialist agent definitions
 prompts/                         # 8 prompt templates + divergent thinking
 guides/                          # 3 deep pattern guides

--- a/docs/03-agents-and-skills.md
+++ b/docs/03-agents-and-skills.md
@@ -95,6 +95,17 @@ Use it: `/project:explain src/auth.py`
 | **Best for** | Reusable prompts with arguments | Complex multi-step workflows |
 | **Complexity** | Simple — just a markdown prompt | Richer — frontmatter, tool restrictions |
 
+### Commands Included in This Repo
+
+This repo ships two ready-to-use commands in `.claude/commands/`:
+
+| Command | Usage | Purpose |
+|---|---|---|
+| `handover` | `/project:handover` | Write a structured session handover to STATUS.md |
+| `reflect` | `/project:reflect` | Review the session and capture reusable learnings |
+
+Try them at the end of any session — they teach you the habit of closing sessions cleanly.
+
 ### Getting Started
 
 Start with agents — they're included in this repo and give you the most control. Move to custom commands once you find yourself typing the same prompt repeatedly.


### PR DESCRIPTION
## Summary

- **2 custom slash commands** added (`.claude/commands/`):
  - `/project:handover` — writes structured session handover to STATUS.md
  - `/project:reflect` — reviews session and captures reusable learnings
- **`file-suggestion.sh` hook** — prioritizes CLAUDE.md, rules, and agents in @ autocomplete
- **`settings.json` enhanced** — fileSuggestion config, Notification hook for idle prompts
- **README.md** — updated counts (10 hooks, 2 commands), structure section updated
- **docs/03-agents-and-skills.md** — added table of included commands

Backported from battle-tested personal setup, sanitized for public template use.

## Test plan

- [ ] Run `/project:handover` in a session — verify STATUS.md is created
- [ ] Run `/project:reflect` — verify it summarizes session learnings
- [ ] Type `@` in Claude Code — verify file suggestions appear
- [ ] Verify all README links resolve to existing files
- [ ] Security review: documentation + shell scripts only, no secrets

Generated with Claude Code