### PR TITLE
feat: add config improvements and observability hooks

### DIFF
--- a/.claude/agents/explorer.md
+++ b/.claude/agents/explorer.md
@@ -1,7 +1,15 @@
 ---
 name: explorer
 description: "Divergent thinking advisor — explore the widest solution space before building."
-tools: Read, Grep, Glob, Bash, WebSearch
+model: sonnet
+permissionMode: plan
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebFetch
+  - WebSearch
 ---
 
 You are a strategic advisor and creative thinker. Your job is DIVERGENT thinking — exploring the widest possible solution space before anyone starts building.

--- a/.claude/hooks/tool-failure-log.sh
+++ b/.claude/hooks/tool-failure-log.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Log failed tool calls for observability
+# Hook: PostToolUseFailure (all tools)
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+ERROR=$(echo "$INPUT" | jq -r '.error // "no error message"')
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[$TIMESTAMP] FAIL: $TOOL_NAME — $ERROR" >> /tmp/claude-tool-failures.log
+
+# Non-blocking — always exit 0
+exit 0

--- a/.claude/hooks/tool-failure-log.sh
+++ b/.claude/hooks/tool-failure-log.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # Log failed tool calls for observability
 # Hook: PostToolUseFailure (all tools)
-
-set -euo pipefail
+# Requires: jq (gracefully skips if missing)
 
 INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
-ERROR=$(echo "$INPUT" | jq -r '.error // "no error message"')
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"' 2>/dev/null) || TOOL_NAME="unknown"
+ERROR=$(echo "$INPUT" | jq -r '.error // "no error message"' 2>/dev/null) || ERROR="no error message"
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+LOG_FILE="${TMPDIR:-/tmp}/claude-tool-failures.log"
 
-echo "[$TIMESTAMP] FAIL: $TOOL_NAME — $ERROR" >> /tmp/claude-tool-failures.log
+echo "[$TIMESTAMP] FAIL: $TOOL_NAME — $ERROR" >> "$LOG_FILE"
 
-# Non-blocking — always exit 0
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,7 +109,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": ".*",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
@@ -121,20 +121,22 @@
     ],
     "InstructionsLoaded": [
       {
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "cat | jq -r \".files[]\" >> /tmp/claude-instructions-loaded.log"
+            "command": "jq -r '.files[]' >> \"${TMPDIR:-/tmp}/claude-instructions-loaded.log\" 2>/dev/null || true"
           }
         ]
       }
     ],
     "ConfigChange": [
       {
+        "matcher": "",
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Config changed during session\" >> /tmp/claude-config-changes.log"
+            "command": "echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Config changed during session\" >> \"${TMPDIR:-/tmp}/claude-config-changes.log\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,12 @@
     "type": "command",
     "command": "bash .claude/hooks/file-suggestion.sh"
   },
+  "autoUpdatesChannel": "stable",
+  "attribution": {
+    "commit": "\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+    "pr": "Generated with Claude Code"
+  },
+  "effortLevel": "high",
   "hooks": {
     "PreToolUse": [
       {
@@ -97,6 +103,38 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/session-end.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/tool-failure-log.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | jq -r \".files[]\" >> /tmp/claude-instructions-loaded.log"
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"[$(date '+%Y-%m-%d %H:%M:%S')] Config changed during session\" >> /tmp/claude-config-changes.log"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- **3 new top-level settings:** `autoUpdatesChannel: "stable"`, `attribution` (commit + PR), `effortLevel: "high"`
- **3 new hook events:** `PostToolUseFailure` (logs failed tool calls), `InstructionsLoaded` (logs loaded instruction files), `ConfigChange` (logs config changes during session)
- **New hook script:** `.claude/hooks/tool-failure-log.sh` — cross-platform, jq-guarded, graceful fallback
- **Explorer agent fix:** proper YAML frontmatter with `model: sonnet`, `permissionMode: plan`, added `WebFetch` to tools

## Details

All new hooks use `${TMPDIR:-/tmp}` for cross-platform temp paths. The tool-failure-log script includes a `jq` availability guard and exits 0 on all code paths (parse failure, missing jq, malformed input).

Ported from local governance session (2026-03-21) — see `~/build-logs/handovers/2026-03-21-governance-to-quickstart.md`.

## Test plan

- [x] JSON validation (`jq .`)
- [x] Shell syntax validation (all 11 hook scripts)
- [x] Hook path integrity (all 11 paths in settings.json resolve to files)
- [x] Executable bit check (all 11 scripts)
- [x] Functional test: tool-failure-log.sh with valid JSON, empty JSON, malformed input
- [x] YAML frontmatter validation (all 9 agent files)
- [x] Schema validation (9 hook events, attribution structure)
- [x] AI review: Claude code-reviewer + Gemini 2.5 Flash (7 findings fixed)

Generated with Claude Code